### PR TITLE
Add real estate bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ This is a simple web page that allows you to track the current value of an inves
 ## Usage
 
 Open `index.html` in a web browser. Fill in the form with your asset information and click **Track** to retrieve the latest price.
+
+## Real Estate Bot
+
+A simple script `real_estate_bot.py` demonstrates how you might analyze Dubai real estate investments. It uses a small sample dataset `dubai_real_estate.csv` and a basic linear regression (implemented without external libraries) to estimate return on investment (ROI). The script prints the top ten properties with the highest predicted ROI.
+
+Run the bot with:
+
+```bash
+python3 real_estate_bot.py
+```
+
+The dataset is illustrative only; replace it with real data to perform meaningful analysis.

--- a/dubai_real_estate.csv
+++ b/dubai_real_estate.csv
@@ -1,0 +1,21 @@
+property_id,location,bedrooms,size_sqft,price,rental_income,property_type
+P1,Downtown,2,900,1500000,90000,apartment
+P2,Dubai Marina,3,1300,2200000,150000,apartment
+P3,Jumeirah,4,2500,3500000,210000,villa
+P4,Business Bay,1,750,1200000,70000,apartment
+P5,Palm Jumeirah,5,4500,8000000,480000,villa
+P6,Dubai Creek,2,1100,1700000,100000,apartment
+P7,Arabian Ranches,3,1800,2500000,160000,villa
+P8,DIFC,2,1000,1900000,110000,apartment
+P9,Deira,1,700,1000000,60000,apartment
+P10,Al Barsha,3,1600,2400000,150000,villa
+P11,Dubai Sports City,2,1200,1600000,90000,apartment
+P12,Silicon Oasis,1,800,900000,55000,apartment
+P13,Dubai Hills,4,3000,4200000,250000,villa
+P14,International City,1,600,700000,45000,apartment
+P15,JLT,2,950,1700000,105000,apartment
+P16,Emirates Hills,6,6000,12000000,720000,villa
+P17,Al Quoz,3,1400,2300000,140000,villa
+P18,Discovery Gardens,1,750,800000,50000,apartment
+P19,Mirdif,3,1500,2100000,130000,villa
+P20,Motor City,2,1100,1600000,95000,apartment

--- a/real_estate_bot.py
+++ b/real_estate_bot.py
@@ -1,0 +1,96 @@
+# Real Estate Bot for Dubai
+# This script loads a sample real estate dataset and uses a simple linear regression
+# implementation (gradient descent) to predict ROI for each property. It then prints
+# the top 10 opportunities based on the predicted ROI.
+
+import csv
+
+DATA_FILE = 'dubai_real_estate.csv'
+LEARNING_RATE = 0.01
+EPOCHS = 1000
+SIZE_SCALE = 6000.0  # max size in dataset
+PRICE_SCALE = 12_000_000.0  # max price in dataset
+
+# Encode categorical values to integers
+def encode(values):
+    mapping = {}
+    encoded = []
+    for v in values:
+        if v not in mapping:
+            mapping[v] = len(mapping)
+        encoded.append(mapping[v])
+    return encoded, mapping
+
+# Load dataset
+def load_dataset(path):
+    data = []
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        locations = []
+        types = []
+        for row in reader:
+            row['bedrooms'] = int(row['bedrooms'])
+            row['size_sqft'] = float(row['size_sqft'])
+            row['price'] = float(row['price'])
+            row['rental_income'] = float(row['rental_income'])
+            data.append(row)
+            locations.append(row['location'])
+            types.append(row['property_type'])
+    loc_encoded, loc_map = encode(locations)
+    type_encoded, type_map = encode(types)
+    for i, row in enumerate(data):
+        row['location_enc'] = loc_encoded[i]
+        row['type_enc'] = type_encoded[i]
+        row['roi'] = row['rental_income'] / row['price']
+    return data, loc_map, type_map
+
+# Prepare features and targets
+def prepare_xy(data):
+    X = []
+    y = []
+    for row in data:
+        size = row['size_sqft'] / SIZE_SCALE
+        price = row['price'] / PRICE_SCALE
+        loc = row['location_enc'] / 10.0
+        typ = row['type_enc'] / 10.0
+        features = [1.0, row['bedrooms'], size, price, loc, typ]
+        X.append(features)
+        y.append(row['roi'])
+    return X, y
+
+# Gradient descent for linear regression
+def train_linear_regression(X, y, epochs=EPOCHS, lr=LEARNING_RATE):
+    n_features = len(X[0])
+    weights = [0.0] * n_features
+    for _ in range(epochs):
+        for features, target in zip(X, y):
+            pred = sum(w * f for w, f in zip(weights, features))
+            error = pred - target
+            for i in range(n_features):
+                weights[i] -= lr * error * features[i]
+    return weights
+
+# Predict using the trained model
+def predict(weights, features):
+    return sum(w * f for w, f in zip(weights, features))
+
+# Main logic
+def main():
+    data, loc_map, type_map = load_dataset(DATA_FILE)
+    X, y = prepare_xy(data)
+    weights = train_linear_regression(X, y)
+    for i, row in enumerate(data):
+        size = row['size_sqft'] / SIZE_SCALE
+        price = row['price'] / PRICE_SCALE
+        loc = row['location_enc'] / 10.0
+        typ = row['type_enc'] / 10.0
+        features = [1.0, row['bedrooms'], size, price, loc, typ]
+        row['predicted_roi'] = predict(weights, features)
+    data.sort(key=lambda r: r['predicted_roi'], reverse=True)
+    print('Top 10 Investment Opportunities (predicted ROI):')
+    for row in data[:10]:
+        print(f"{row['property_id']} - Location: {row['location']} - Price: {row['price']} - "
+              f"Rental: {row['rental_income']} - Predicted ROI: {row['predicted_roi']:.4f}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `real_estate_bot.py` demonstrating a simple ML model on a small Dubai dataset
- include sample `dubai_real_estate.csv`
- document how to run the bot in README

## Testing
- `python3 real_estate_bot.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68880979efd483269507ef53c3e50ba7