### PR TITLE
Add real estate scraper and integrate with bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ This is a simple web page that allows you to track the current value of an inves
 ## Usage
 
 Open `index.html` in a web browser. Fill in the form with your asset information and click **Track** to retrieve the latest price.
+
+## Real Estate Bot
+
+A simple script `real_estate_bot.py` demonstrates how you might analyze Dubai real estate investments. It uses a dataset `dubai_real_estate.csv` generated from multiple listing pages and a basic linear regression (implemented without external libraries) to estimate return on investment (ROI). The script prints the top ten properties with the highest predicted ROI.
+
+To build the dataset from several listing pages (or example HTML files), run:
+
+```bash
+python3 scrape_dubai_listings.py
+```
+
+This combines all listings into `dubai_real_estate.csv`.
+
+Run the bot with:
+
+```bash
+python3 real_estate_bot.py
+```
+
+The dataset is illustrative only; replace it with real data to perform meaningful analysis.

--- a/dubai_real_estate.csv
+++ b/dubai_real_estate.csv
@@ -1,0 +1,21 @@
+property_id,location,bedrooms,size_sqft,price,rental_income,property_type
+P1,Downtown,2,900,1500000,90000,apartment
+P2,Dubai Marina,3,1300,2200000,150000,apartment
+P3,Jumeirah,4,2500,3500000,210000,villa
+P4,Business Bay,1,750,1200000,70000,apartment
+P5,Palm Jumeirah,5,4500,8000000,480000,villa
+P6,Dubai Creek,2,1100,1700000,100000,apartment
+P7,Arabian Ranches,3,1800,2500000,160000,villa
+P8,DIFC,2,1000,1900000,110000,apartment
+P9,Deira,1,700,1000000,60000,apartment
+P10,Al Barsha,3,1600,2400000,150000,villa
+P11,Dubai Sports City,2,1200,1600000,90000,apartment
+P12,Silicon Oasis,1,800,900000,55000,apartment
+P13,Dubai Hills,4,3000,4200000,250000,villa
+P14,International City,1,600,700000,45000,apartment
+P15,JLT,2,950,1700000,105000,apartment
+P16,Emirates Hills,6,6000,12000000,720000,villa
+P17,Al Quoz,3,1400,2300000,140000,villa
+P18,Discovery Gardens,1,750,800000,50000,apartment
+P19,Mirdif,3,1500,2100000,130000,villa
+P20,Motor City,2,1100,1600000,95000,apartment

--- a/real_estate_bot.py
+++ b/real_estate_bot.py
@@ -1,0 +1,101 @@
+# Real Estate Bot for Dubai
+# This script loads a sample real estate dataset and uses a simple linear regression
+# implementation (gradient descent) to predict ROI for each property. It then prints
+# the top 10 opportunities based on the predicted ROI.
+
+import csv
+import os
+import sys
+
+DATA_FILE = 'dubai_real_estate.csv'
+LEARNING_RATE = 0.01
+EPOCHS = 1000
+SIZE_SCALE = 6000.0  # max size in dataset
+PRICE_SCALE = 12_000_000.0  # max price in dataset
+
+# Encode categorical values to integers
+def encode(values):
+    mapping = {}
+    encoded = []
+    for v in values:
+        if v not in mapping:
+            mapping[v] = len(mapping)
+        encoded.append(mapping[v])
+    return encoded, mapping
+
+# Load dataset
+def load_dataset(path):
+    data = []
+    with open(path, newline='') as f:
+        reader = csv.DictReader(f)
+        locations = []
+        types = []
+        for row in reader:
+            row['bedrooms'] = int(row['bedrooms'])
+            row['size_sqft'] = float(row['size_sqft'])
+            row['price'] = float(row['price'])
+            row['rental_income'] = float(row['rental_income'])
+            data.append(row)
+            locations.append(row['location'])
+            types.append(row['property_type'])
+    loc_encoded, loc_map = encode(locations)
+    type_encoded, type_map = encode(types)
+    for i, row in enumerate(data):
+        row['location_enc'] = loc_encoded[i]
+        row['type_enc'] = type_encoded[i]
+        row['roi'] = row['rental_income'] / row['price']
+    return data, loc_map, type_map
+
+# Prepare features and targets
+def prepare_xy(data):
+    X = []
+    y = []
+    for row in data:
+        size = row['size_sqft'] / SIZE_SCALE
+        price = row['price'] / PRICE_SCALE
+        loc = row['location_enc'] / 10.0
+        typ = row['type_enc'] / 10.0
+        features = [1.0, row['bedrooms'], size, price, loc, typ]
+        X.append(features)
+        y.append(row['roi'])
+    return X, y
+
+# Gradient descent for linear regression
+def train_linear_regression(X, y, epochs=EPOCHS, lr=LEARNING_RATE):
+    n_features = len(X[0])
+    weights = [0.0] * n_features
+    for _ in range(epochs):
+        for features, target in zip(X, y):
+            pred = sum(w * f for w, f in zip(weights, features))
+            error = pred - target
+            for i in range(n_features):
+                weights[i] -= lr * error * features[i]
+    return weights
+
+# Predict using the trained model
+def predict(weights, features):
+    return sum(w * f for w, f in zip(weights, features))
+
+# Main logic
+def main():
+    data, loc_map, type_map = load_dataset(DATA_FILE)
+    X, y = prepare_xy(data)
+    weights = train_linear_regression(X, y)
+    for i, row in enumerate(data):
+        size = row['size_sqft'] / SIZE_SCALE
+        price = row['price'] / PRICE_SCALE
+        loc = row['location_enc'] / 10.0
+        typ = row['type_enc'] / 10.0
+        features = [1.0, row['bedrooms'], size, price, loc, typ]
+        row['predicted_roi'] = predict(weights, features)
+    data.sort(key=lambda r: r['predicted_roi'], reverse=True)
+    print('Top 10 Investment Opportunities (predicted ROI):')
+    for row in data[:10]:
+        print(f"{row['property_id']} - Location: {row['location']} - Price: {row['price']} - "
+              f"Rental: {row['rental_income']} - Predicted ROI: {row['predicted_roi']:.4f}")
+
+if __name__ == '__main__':
+    if '--scrape' in sys.argv or not os.path.exists(DATA_FILE):
+        import scrape_dubai_listings
+        scrape_dubai_listings.scrape_urls(['site1.html', 'site2.html'])
+    main()

--- a/scrape_dubai_listings.py
+++ b/scrape_dubai_listings.py
@@ -1,0 +1,75 @@
+"""Scrape multiple Dubai real estate listing pages and combine them into a CSV.
+This example uses local HTML files but works with HTTP URLs as well.
+"""
+
+import csv
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+FIELDS = [
+    "property_id",
+    "location",
+    "bedrooms",
+    "size_sqft",
+    "price",
+    "rental_income",
+    "property_type",
+]
+
+
+class ListingParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.listings = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "div":
+            return
+        attr = dict(attrs)
+        if attr.get("class") != "listing":
+            return
+        self.listings.append(
+            {
+                "property_id": attr.get("data-id", ""),
+                "location": attr.get("data-location", ""),
+                "bedrooms": attr.get("data-bedrooms", "0"),
+                "size_sqft": attr.get("data-size", "0"),
+                "price": attr.get("data-price", "0"),
+                "rental_income": attr.get("data-rental", "0"),
+                "property_type": attr.get("data-type", ""),
+            }
+        )
+
+
+def fetch_content(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme in {"http", "https"}:
+        with urlopen(url) as resp:
+            return resp.read().decode()
+    else:
+        with open(url, "r") as f:
+            return f.read()
+
+
+def scrape_urls(urls, output_csv="dubai_real_estate.csv"):
+    all_rows = []
+    for url in urls:
+        html = fetch_content(url)
+        parser = ListingParser()
+        parser.feed(html)
+        all_rows.extend(parser.listings)
+
+    with open(output_csv, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDS)
+        writer.writeheader()
+        for row in all_rows:
+            writer.writerow(row)
+    return all_rows
+
+
+if __name__ == "__main__":
+    # Replace these with real URLs when available
+    urls = ["site1.html", "site2.html"]
+    scraped = scrape_urls(urls)
+    print(f"Wrote {len(scraped)} listings to dubai_real_estate.csv")

--- a/site1.html
+++ b/site1.html
@@ -1,0 +1,12 @@
+<html><body>
+<div class="listing" data-id="P1" data-location="Downtown" data-bedrooms="2" data-size="900" data-price="1500000" data-rental="90000" data-type="apartment"></div>
+<div class="listing" data-id="P2" data-location="Dubai Marina" data-bedrooms="3" data-size="1300" data-price="2200000" data-rental="150000" data-type="apartment"></div>
+<div class="listing" data-id="P3" data-location="Jumeirah" data-bedrooms="4" data-size="2500" data-price="3500000" data-rental="210000" data-type="villa"></div>
+<div class="listing" data-id="P4" data-location="Business Bay" data-bedrooms="1" data-size="750" data-price="1200000" data-rental="70000" data-type="apartment"></div>
+<div class="listing" data-id="P5" data-location="Palm Jumeirah" data-bedrooms="5" data-size="4500" data-price="8000000" data-rental="480000" data-type="villa"></div>
+<div class="listing" data-id="P6" data-location="Dubai Creek" data-bedrooms="2" data-size="1100" data-price="1700000" data-rental="100000" data-type="apartment"></div>
+<div class="listing" data-id="P7" data-location="Arabian Ranches" data-bedrooms="3" data-size="1800" data-price="2500000" data-rental="160000" data-type="villa"></div>
+<div class="listing" data-id="P8" data-location="DIFC" data-bedrooms="2" data-size="1000" data-price="1900000" data-rental="110000" data-type="apartment"></div>
+<div class="listing" data-id="P9" data-location="Deira" data-bedrooms="1" data-size="700" data-price="1000000" data-rental="60000" data-type="apartment"></div>
+<div class="listing" data-id="P10" data-location="Al Barsha" data-bedrooms="3" data-size="1600" data-price="2400000" data-rental="150000" data-type="villa"></div>
+</body></html>

--- a/site2.html
+++ b/site2.html
@@ -1,0 +1,12 @@
+<html><body>
+<div class="listing" data-id="P11" data-location="Dubai Sports City" data-bedrooms="2" data-size="1200" data-price="1600000" data-rental="90000" data-type="apartment"></div>
+<div class="listing" data-id="P12" data-location="Silicon Oasis" data-bedrooms="1" data-size="800" data-price="900000" data-rental="55000" data-type="apartment"></div>
+<div class="listing" data-id="P13" data-location="Dubai Hills" data-bedrooms="4" data-size="3000" data-price="4200000" data-rental="250000" data-type="villa"></div>
+<div class="listing" data-id="P14" data-location="International City" data-bedrooms="1" data-size="600" data-price="700000" data-rental="45000" data-type="apartment"></div>
+<div class="listing" data-id="P15" data-location="JLT" data-bedrooms="2" data-size="950" data-price="1700000" data-rental="105000" data-type="apartment"></div>
+<div class="listing" data-id="P16" data-location="Emirates Hills" data-bedrooms="6" data-size="6000" data-price="12000000" data-rental="720000" data-type="villa"></div>
+<div class="listing" data-id="P17" data-location="Al Quoz" data-bedrooms="3" data-size="1400" data-price="2300000" data-rental="140000" data-type="villa"></div>
+<div class="listing" data-id="P18" data-location="Discovery Gardens" data-bedrooms="1" data-size="750" data-price="800000" data-rental="50000" data-type="apartment"></div>
+<div class="listing" data-id="P19" data-location="Mirdif" data-bedrooms="3" data-size="1500" data-price="2100000" data-rental="130000" data-type="villa"></div>
+<div class="listing" data-id="P20" data-location="Motor City" data-bedrooms="2" data-size="1100" data-price="1600000" data-rental="95000" data-type="apartment"></div>
+</body></html>


### PR DESCRIPTION
## Summary
- show how to build dataset from multiple websites with `scrape_dubai_listings.py`
- integrate scraper option into `real_estate_bot.py`
- include example HTML listing pages

## Testing
- `python3 scrape_dubai_listings.py`
- `python3 real_estate_bot.py | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68880979efd483269507ef53c3e50ba7